### PR TITLE
Mirror of cisco libacvp#63

### DIFF
--- a/src/acvp_lcl.h
+++ b/src/acvp_lcl.h
@@ -111,14 +111,14 @@
 #define ACVP_ALG_DSA                 "DSA2"
 #define ACVP_DSA_PQGGEN              "pqgGen"
 
-#define ACVP_ALG_RSA_KEYGEN             "keyGen"
-#define ACVP_ALG_RSA_SIGGEN             "sigGen"
-#define ACVP_ALG_RSA_SIGVER             "sigVer"
+#define ACVP_ALG_RSA_KEYGEN             "RSA-keyGen"
+#define ACVP_ALG_RSA_SIGGEN             "RSA-sigGen"
+#define ACVP_ALG_RSA_SIGVER             "RSA-sigVer"
 
-#define ACVP_ALG_ECDSA_KEYGEN           "keyGen"
-#define ACVP_ALG_ECDSA_KEYVER           "keyVer"
-#define ACVP_ALG_ECDSA_SIGGEN           "sigGen"
-#define ACVP_ALG_ECDSA_SIGVER           "sigVer"
+#define ACVP_ALG_ECDSA_KEYGEN           "ECDSA-keyGen"
+#define ACVP_ALG_ECDSA_KEYVER           "ECDSA-keyVer"
+#define ACVP_ALG_ECDSA_SIGGEN           "ECDSA-sigGen"
+#define ACVP_ALG_ECDSA_SIGVER           "ECDSA-sigVer"
 
 #define ACVP_PREREQ_VAL_STR "valValue"
 #define ACVP_PREREQ_OBJ_STR "prereqVals"

--- a/src/acvp_rsa_keygen.c
+++ b/src/acvp_rsa_keygen.c
@@ -195,7 +195,7 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler (ACVP_CTX *ctx, JSON_Object *obj) {
     int info_gen_by_server, rand_pq, seed_len;
     char *pub_exp_mode, *key_format, *prime_test;
     char *hash_alg = NULL;
-    char *e_str = NULL, *alg_str, *mode_str, *seed;
+    char *e_str = NULL, *alg_str, *mode_str, *seed, *alg_tbl_index;
     int bitlen1, bitlen2, bitlen3, bitlen4;
     
     alg_str = (char *) json_object_get_string(obj, "algorithm");
@@ -207,11 +207,17 @@ ACVP_RESULT acvp_rsa_keygen_kat_handler (ACVP_CTX *ctx, JSON_Object *obj) {
     tc.tc.rsa_keygen = &stc;
     mode_str = (char *) json_object_get_string(obj, "mode");
     
-
+    
+    /* allocate space to concatenate alg and mode strings (and a hyphen) */
+    alg_tbl_index = calloc(strnlen(alg_str, 5) + 6 + 1, sizeof(char));
+    strncat(alg_tbl_index, alg_str, 5);
+    strncat(alg_tbl_index, "-", 1);
+    strncat(alg_tbl_index, mode_str, 6);
+    
     /*
      * Get the crypto module handler for this hash algorithm
      */
-    alg_id = acvp_lookup_cipher_index(mode_str);
+    alg_id = acvp_lookup_cipher_index(alg_tbl_index);
     switch(alg_id) {
     case ACVP_RSA_KEYGEN:
         break;

--- a/src/acvp_rsa_sig.c
+++ b/src/acvp_rsa_sig.c
@@ -164,7 +164,7 @@ ACVP_RESULT acvp_rsa_sig_kat_handler (ACVP_CTX *ctx, JSON_Object *obj) {
     unsigned int mod = 0;
     unsigned char *msg, *signature;
     char *e_str = NULL, *n_str = NULL;
-    char *hash_alg = NULL, *sig_type, *salt, *alg_str;
+    char *hash_alg = NULL, *sig_type, *salt, *alg_str, *alg_tbl_index;
 
     ACVP_RESULT rv;
     alg_str = (char *) json_object_get_string(obj, "algorithm");
@@ -176,10 +176,16 @@ ACVP_RESULT acvp_rsa_sig_kat_handler (ACVP_CTX *ctx, JSON_Object *obj) {
     tc.tc.rsa_sig = &stc;
     mode_str = (char *) json_object_get_string(obj, "mode");
     
+    /* allocate space to concatenate alg and mode strings (and a hyphen) */
+    alg_tbl_index = calloc(strnlen(alg_str, 5) + 6 + 1, sizeof(char));
+    strncat(alg_tbl_index, alg_str, 5);
+    strncat(alg_tbl_index, "-", 1);
+    strncat(alg_tbl_index, mode_str, 6);
+    
     /*
      * Get the crypto module handler for this hash algorithm
      */
-    alg_id = acvp_lookup_cipher_index(mode_str);
+    alg_id = acvp_lookup_cipher_index(alg_tbl_index);
     switch(alg_id) {
     case ACVP_RSA_SIGGEN:
     case ACVP_RSA_SIGVER:


### PR DESCRIPTION
Mirror of cisco libacvp#63
So that the library code passes the test cases to the proper application handler
