### PR TITLE
Mirror of cisco libacvp#317

### DIFF
--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -692,6 +692,8 @@
 
 
 #define ACVP_USER_AGENT_STR_MAX 255
+//each char in this string cannot exist in the actual values for the user-agent
+#define ACVP_USER_AGENT_DELIMITERS "/;"
 /*
  * Max lengths for different values in the HTTP user-agent string, arbitrarily selected
  */

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -690,6 +690,29 @@
 
 #define ACVP_CFB1_BIT_MASK      0x80
 
+
+#define ACVP_USER_AGENT_STR_MAX 255
+/*
+ * Max lengths for different values in the HTTP user-agent string, arbitrarily selected
+ */
+#define ACVP_USER_AGENT_ACVP_STR_MAX 16
+#define ACVP_USER_AGENT_OSNAME_STR_MAX 32
+#define ACVP_USER_AGENT_OSVER_STR_MAX 64
+#define ACVP_USER_AGENT_ARCH_STR_MAX 16
+#define ACVP_USER_AGENT_PROC_STR_MAX 64
+#define ACVP_USER_AGENT_COMP_STR_MAX 32
+
+/*
+ * If library cannot detect hardware or software info for HTTP user-agent string, we can check for them
+ * in environmental variables, which are defined here
+ */
+#define ACVP_USER_AGENT_ENV_NAME_MAX 19 //all values below must have length <= this
+#define ACVP_USER_AGENT_OSNAME_ENV "ACV_OE_OSNAME"
+#define ACVP_USER_AGENT_OSVER_ENV "ACV_OE_OSVERSION"
+#define ACVP_USER_AGENT_ARCH_ENV "ACV_OE_ARCHITECTURE"
+#define ACVP_USER_AGENT_PROC_ENV "ACV_OE_PROCESSOR"
+#define ACVP_USER_AGENT_COMP_ENV "ACV_OE_COMPILER"
+
 typedef struct acvp_alg_handler_t ACVP_ALG_HANDLER;
 
 struct acvp_alg_handler_t {
@@ -1272,6 +1295,8 @@ struct acvp_ctx_t {
     int verify_peer;        /* enables TLS peer verification via Curl */
     char *tls_cert;         /* Location of PEM encoded X509 cert to use for TLS client auth */
     char *tls_key;          /* Location of PEM encoded priv key to use for TLS client auth */
+
+    char *http_user_agent;   /* String containing info to be sent with HTTP requests, currently OE info */
     
     ACVP_OPERATING_ENV op_env; /**< The Operating Environment resources available */
     ACVP_STRING_LIST *vsid_url_list;

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -692,8 +692,10 @@
 
 
 #define ACVP_USER_AGENT_STR_MAX 255
-//each char in this string cannot exist in the actual values for the user-agent
-#define ACVP_USER_AGENT_DELIMITERS "/;"
+//char cannot exist in any string for http user agent for parsing reasons
+#define ACVP_USER_AGENT_DELIMITER ';'
+#define ACVP_USER_AGENT_CHAR_REPLACEMENT '_';
+
 /*
  * Max lengths for different values in the HTTP user-agent string, arbitrarily selected
  */

--- a/include/acvp/acvp_lcl.h
+++ b/include/acvp/acvp_lcl.h
@@ -710,7 +710,6 @@
  * If library cannot detect hardware or software info for HTTP user-agent string, we can check for them
  * in environmental variables, which are defined here
  */
-#define ACVP_USER_AGENT_ENV_NAME_MAX 19 //all values below must have length <= this
 #define ACVP_USER_AGENT_OSNAME_ENV "ACV_OE_OSNAME"
 #define ACVP_USER_AGENT_OSVER_ENV "ACV_OE_OSVERSION"
 #define ACVP_USER_AGENT_ARCH_ENV "ACV_OE_ARCHITECTURE"

--- a/safe_c_stub/include/safe_str_lib.h
+++ b/safe_c_stub/include/safe_str_lib.h
@@ -91,4 +91,7 @@ extern errno_t strspn_s(const char *dest, rsize_t dmax, const char *src,  rsize_
 /* determine if character is a digit*/
 extern int strisdigit_s(const char *dest, rsize_t dmax);
 
+/* remove leading and trailing whitespice*/
+extern errno_t strremovews_s(char *s, rsize_t smax);
+
 #endif /* __SAFE_STR_LIB_H__ */

--- a/safe_c_stub/include/safe_str_lib.h
+++ b/safe_c_stub/include/safe_str_lib.h
@@ -91,7 +91,7 @@ extern errno_t strspn_s(const char *dest, rsize_t dmax, const char *src,  rsize_
 /* determine if character is a digit*/
 extern int strisdigit_s(const char *dest, rsize_t dmax);
 
-/* remove leading and trailing whitespice*/
+/* remove leading and trailing whitespace*/
 extern errno_t strremovews_s(char *s, rsize_t smax);
 
 #endif /* __SAFE_STR_LIB_H__ */

--- a/safe_c_stub/src/safe_str_stub.c
+++ b/safe_c_stub/src/safe_str_stub.c
@@ -588,3 +588,72 @@ strtok_s (char *dest, rsize_t *dmax, const char *src, char **ptr)
     *dmax = dlen;
     return (ptoken);
 }
+
+/*
+ * strremovews_s
+ */
+errno_t strremovews_s (char *s, rsize_t smax) {
+	if (!s) return (ESNULLP);
+	if (smax == 0) return (ESZEROL);
+	
+	    if (smax <= RSIZE_MIN_STR) {
+        *s = '\0';
+        return (EOK);
+    }
+
+    char *orig_s;
+    rsize_t orig_smax;
+    char *new_s;
+
+    orig_s = s;
+    orig_smax = smax;
+    new_s = s;
+
+    while ((*s == ' ') || (*s == '\t')) {
+
+        if (smax == 0) {
+            while (orig_smax) { *orig_s++ = '\0';  orig_smax--; }
+            return (ESUNTERM);
+        }
+        smax--; 
+
+        s++;
+    } 
+
+
+	
+    if (new_s != s) { 
+        while (*s) {
+
+            if (smax == 0) {
+                while (orig_smax) { *orig_s++ = '\0';  orig_smax--; }
+                return (ESUNTERM);
+            }
+            smax--;
+
+            *new_s++ = *s;
+            *s++ = ' '; 
+        } 
+        *new_s = '\0';
+
+    } else { 
+        while (*s) {
+
+            if (smax == 0) {
+                while (orig_smax) { *orig_s++ = '\0';  orig_smax--; };
+                return (ESUNTERM);
+            }
+            smax--;
+
+            s++;
+        }
+    }  
+
+    s--; 
+    while ((*s == ' ') || (*s == '\t') || (*s == '\0')) {
+        *s = '\0'; 
+        s--;
+    } 
+
+    return (EOK);
+}

--- a/src/acvp.c
+++ b/src/acvp.c
@@ -596,6 +596,7 @@ ACVP_RESULT acvp_free_test_session(ACVP_CTX *ctx) {
     if (ctx->cacerts_file) { free(ctx->cacerts_file); }
     if (ctx->tls_cert) { free(ctx->tls_cert); }
     if (ctx->tls_key) { free(ctx->tls_key); }
+    if (ctx->http_user_agent) { free(ctx->http_user_agent); }
     if (ctx->json_filename) { free(ctx->json_filename); }
     if (ctx->session_url) { free(ctx->session_url); }
     if (ctx->vector_req_file) { free(ctx->vector_req_file); }

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -264,6 +264,7 @@ static void acvp_http_user_agent_handler(ACVP_CTX *ctx, char *agent_string) {
         return;
     } else if (strnlen_s(agent_string, 1) > 0) {
         ACVP_LOG_WARN("HTTP user-agent string already contains data, skipping...\n");
+        return;
     }
 
     char *libver = calloc(ACVP_USER_AGENT_ACVP_STR_MAX + 1, sizeof(char));
@@ -370,7 +371,7 @@ static void acvp_http_user_agent_handler(ACVP_CTX *ctx, char *agent_string) {
                 //Windows uses UTF16, and everyone else uses UTF8
                 char *utf8String = calloc(bufferLength + 1, sizeof(char));
                 if (!WideCharToMultiByte(CP_UTF8, 0, buildLabBuffer, -1, utf8String, bufferLength + 1, NULL, NULL)) {
-                    ACVP_LOG_ERR("Error converting Windows build info to UTF8! Checking environment or omitting...");
+                    ACVP_LOG_ERR("Error converting Windows build info to UTF8! Checking environment or omitting from HTTP user-agent...");
                     acvp_http_user_agent_check_env_for_var(ctx, osver, ACVP_USER_AGENT_OSVER);
                 } else {
                     strncpy_s(osver, ACVP_USER_AGENT_OSVER_STR_MAX + 1, utf8String, ACVP_USER_AGENT_OSVER_STR_MAX);

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -439,6 +439,10 @@ static void acvp_http_user_agent_handler(ACVP_CTX *ctx, char *agent_string) {
     acvp_http_user_agent_check_compiler_ver(ctx, comp);
 
 #else
+    /*******************************************************
+     * Code for getting OE information on platforms that   *
+     * are not Windows, Linux, or Mac OS can be added here *
+     *******************************************************/
     acvp_http_user_agent_check_env_for_var(ctx, osname, ACVP_USER_AGENT_OSNAME);
     acvp_http_user_agent_check_env_for_var(ctx, osver, ACVP_USER_AGENT_OSVER);
     acvp_http_user_agent_check_env_for_var(ctx, arch, ACVP_USER_AGENT_ARCH);

--- a/src/acvp_transport.c
+++ b/src/acvp_transport.c
@@ -203,13 +203,12 @@ static void acvp_http_user_agent_check_env_for_var(ACVP_CTX *ctx, char *var_stri
         if (strnlen_s(envVal, maxLength + 1) > maxLength) {
             ACVP_LOG_WARN("Environment-provided %s string too long! (%d char max.) Omitting...\n", var, maxLength);
         } else {
-            strncat_s(var_string, maxLength + 1, envVal, maxLength);
+            strncpy_s(var_string, maxLength + 1, envVal, maxLength);
         }
     } else {
         ACVP_LOG_WARN("Unable to collect info for HTTP user-agent - please define %s (%d char max.)", var, maxLength);
     }
 }
-
 
 static void acvp_http_user_agent_check_compiler_ver(ACVP_CTX *ctx, char *comp_string) {
     char versionBuffer[16];


### PR DESCRIPTION
Mirror of cisco libacvp#317
The HTTP User-agent now consists of: 

Library name/version; OS name; os/kernel version; processor architecture; processor name; compiler/version.

On Linux, Windows, and Mac OS on x86 or x64 platforms, this is all automatically populated. In other situations, depending on the environment, some of this information may be populated. For any information that cannot be found, an environment variable can be defined (undefined variables for info not automatically detected by the library throw a warning but do not prevent user from continuing).

Tested on Ubuntu, Windows 10, and Mac OS.

The Safe C Stub now contains function strremovews_s, which allows for leading and trailing white space on strings to be safely removed.
